### PR TITLE
Creating a copy of the thumbnail in the OOD directory

### DIFF
--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+OOD_OUTPUT_DIR="$(pwd)"
+
 # Set working directory to home directory
 cd "${HOME}"
 
@@ -183,3 +185,5 @@ echo "$command"
 eval "$command"
 
 echo "TIMING - Finished Image Registration at: $(date)"
+
+cp ${TEMP_DIR}/${REFERENCE_BASENAME}/overlaps/*rigid_overlap.png ${OOD_OUTPUT_DIR}/registration_thumbnail.png


### PR DESCRIPTION
This PR adds a way to visualize the result of the registration process by copying the generated thumbnail into the OOD working directory of the corresponding job.