### PR TITLE
Fixed argument name

### DIFF
--- a/scripts/readers.json
+++ b/scripts/readers.json
@@ -6,7 +6,7 @@
     "BioFormatsSlideReaderZ":{
         "description": "Read slides using BioFormats at a specific Z slice",
         "arguments": {
-            "z": {
+            "z_slice": {
                 "widget": "number_field",
                 "label": "Select a Z slice index",
                 "value": 0,


### PR DESCRIPTION
This PR changes the name of the `BioFormatsSlideReaderZ` from `z` to `z_slice` in the `scripts/readers.json` file.